### PR TITLE
filelock 3.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,10 +19,10 @@ requirements:
   host:
     - pip
     - python
-    - setuptools >= 41.0.0
-    - wheel >= 0.30.0
+    - setuptools >=41.0.0
+    - wheel >=0.30.0
     # needed to get correct version number in the metadata
-    - setuptools_scm >= 2
+    - setuptools_scm >=2
   run:
     - python >=3.6
 


### PR DESCRIPTION
Update filelock to 3.3.1

Category:  miniconda | subcategory:  dependency | pkg_type:  python
Popularity:  4526187 downloads -  filelock  3.3.1  A platform independent file lock.
Version change: bump version number from 3.0.12 to 3.3.1
  license: Public Domain
Release date:  Oct 15, 2021
Bug Tracker: new open issues https://github.com/benediktschmitt/py-filelock/issues
License file:  https://github.com/benediktschmitt/py-filelock/blob/master/LICENSE
Upstream setup.cfg:  https://github.com/tox-dev/py-filelock/blob/3.3.1/setup.cfg
Upstream setup.py:  https://github.com/benediktschmitt/py-filelock/blob/main/setup.py
Upstream pyproject.toml:  https://github.com/tox-dev/py-filelock/blob/3.3.1/pyproject.toml

The package filelock is mentioned inside the packages:
bandersnatch | chainer | conda-build | huggingface_hub | neon | ray-packages | theano-pymc | virtualenv |

Actions:
1. Add missing packages: `wheel`, `setuptools`, `setuptools_scm`
2. Update python
3. Add `pip ` and `python <3.10` in test/requires
4. Add `pip check`

Result:
- all-succeeded
