### PR TITLE
Update FileLock to Version 3.3.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "filelock" %}
-{% set version = "3.3.1" %}
+{% set version = "3.3.2" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 source:
    fn: {{ name }}-{{ version }}.tar.gz
    url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-   sha256: 34a9f35f95c441e7b38209775d6e0337f9a3759f3565f6c5798f19618527c76f
+   sha256: 7afc856f74fa7006a289fd10fa840e1eebd8bbff6bffb69c26c54a0512ea8cf8
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -37,7 +37,7 @@ test:
 
 about:
   home: https://github.com/benediktschmitt/py-filelock
-  license: Public Domain
+  license: Unlicense
   license_family: Public-Domain
   license_file: LICENSE
   summary: 'A platform independent file lock.'


### PR DESCRIPTION
1. check the upstream
https://github.com/tox-dev/py-filelock/tree/3.3.2
2. check the pinnings
https://github.com/tox-dev/py-filelock/blob/3.3.2/whitelist.txt
https://github.com/tox-dev/py-filelock/blob/3.3.2/tox.ini
https://github.com/tox-dev/py-filelock/blob/3.3.2/setup.py
https://github.com/tox-dev/py-filelock/blob/3.3.2/setup.cfg
https://github.com/tox-dev/py-filelock/blob/3.3.2/pyproject.toml

3. check changelogs
https://github.com/tox-dev/py-filelock/blob/3.3.2/docs/changelog.rst

there are no breaking changes included in the change log, 
the changes mentioned were new features

- Accept path types (like `pathlib.Path` and `pathlib.PurePath`) in the constructor for `FileLock` objects.

4. additional research
https://github.com/conda-forge/filelock-feedstock/issues

There are currently no open issues in conda forge

5. verify dev_url
    https://github.com/benediktschmitt/py-filelock
6. verify doc_url
    https://filelock.readthedocs.io/en/latest/
7. verify that pip is in the test section
8. verify the test section
9. additional tests


In order to test the `filelock` package version `3.3.2` the following command was used:
`conda build filelock-feedstock --test` 
The test result was the following:
`All tests passed`

In addition the `neon` package was used to test the `filelock` package import. the pinnings for `filelock` were modified to `3.3.2`

The command was used: `conda build neon-feedstock --test`
The test result was the following: `All tests passed` 

Based on the research findings and on the test results we can conclude that it is safe to update `filelock` to version `3.3.2`
