### PR TITLE
filelock 3.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "filelock" %}
-{% set version = "3.3.1" %}
+{% set version = "3.4.0" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 source:
    fn: {{ name }}-{{ version }}.tar.gz
    url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-   sha256: 34a9f35f95c441e7b38209775d6e0337f9a3759f3565f6c5798f19618527c76f
+   sha256: 93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -37,10 +37,10 @@ test:
 
 about:
   home: https://github.com/benediktschmitt/py-filelock
-  license: Public Domain
+  license: Unlicense
   license_family: Public-Domain
   license_file: LICENSE
-  summary: 'A platform independent file lock.'
+  summary: A platform independent file lock.
 
   description: |
     A filelock provides a synchronisation mechanism between different


### PR DESCRIPTION
Update filelock to 3.4.0

Bug Tracker: new open issues https://github.com/benediktschmitt/py-filelock/issues
Upstream license:  License file:  https://github.com/benediktschmitt/py-filelock/blob/master/LICENSE
Upstream setup.cfg: https://github.com/tox-dev/py-filelock/blob/3.4.0/setup.cfg
Upstream pyproject.toml: https://github.com/tox-dev/py-filelock/blob/3.4.0/pyproject.toml

The package filelock is mentioned inside the packages:
bandersnatch | chainer | conda-build | huggingface_hub | neon | ray-packages | theano-pymc | virtualenv |

Actions:
1. Fix license
2. Reset build number to 0

Result:
- all-succeeded
