### PR TITLE
filelock 3.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     # needed to get correct version number in the metadata
     - setuptools_scm >=2
   run:
-    - python >=3.6
+    - python >=3.7
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "filelock" %}
-{% set version = "3.4.0" %}
+{% set version = "3.4.2" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4
+  sha256: 38b4f4c989f9d06d44524df1b24bd19e167d851f19b50bf3e3559952dddc5b80
 
 build:
   noarch: python


### PR DESCRIPTION
Update filelock to 3.4.2

Bug Tracker: new open issues https://github.com/benediktschmitt/py-filelock/issues
Upstream license: License file: https://github.com/benediktschmitt/py-filelock/blob/master/LICENSE
Upstream setup.cfg: https://github.com/tox-dev/py-filelock/blob/3.4.2/setup.cfg
Upstream pyproject.toml: https://github.com/tox-dev/py-filelock/blob/3.4.2/pyproject.toml

The package filelock is mentioned inside the packages:
bandersnatch | chainer | conda-build | huggingface_hub | neon | ray-packages | theano-pymc | virtualenv |

Actions:
1. Use `python >=3.7`, because version 3.4.2 no longer support python 3.6, see https://github.com/tox-dev/py-filelock/commit/b5e956c3a8e4bc80430209b3136dfb2a6f953d83

Result:

all-succeeded