### PR TITLE
filelock 3.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
 
 requirements:
   host:
@@ -30,13 +30,12 @@ test:
   imports:
     - filelock
   requires:
-    - python <3.10
     - pip
   commands:
     - pip check
 
 about:
-  home: https://github.com/benediktschmitt/py-filelock
+  home: https://github.com/tox-dev/py-filelock
   license: Unlicense
   license_family: Public-Domain
   license_file: LICENSE
@@ -49,9 +48,9 @@ about:
     currently used or manipulated (Think of a sync.lock file). Only the
     existence of the lockfile is watched for this purpose. The file itself
     can not be written and is always empty.
-  doc_url: https://filelock.readthedocs.io/en/latest/
-  dev_url: https://github.com/benediktschmitt/py-filelock
-  doc_source_url: https://github.com/benediktschmitt/py-filelock/tree/master/docs
+  doc_url: https://py-filelock.readthedocs.io/en/latest/
+  dev_url: https://github.com/tox-dev/py-filelock
+  doc_source_url: https://github.com/tox-dev/py-filelock/tree/master/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "filelock" %}
-{% set version = "3.4.2" %}
+{% set version = "3.6.0" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 38b4f4c989f9d06d44524df1b24bd19e167d851f19b50bf3e3559952dddc5b80
+  sha256: 9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85
 
 build:
   noarch: python


### PR DESCRIPTION
Update filelock to 3.6.0

License: https://github.com/tox-dev/py-filelock/blob/3.6.0/LICENSE
Changelog: https://github.com/tox-dev/py-filelock/blob/3.6.0/docs/changelog.rst
Requirements: 
- https://github.com/tox-dev/py-filelock/blob/3.6.0/pyproject.toml
- https://github.com/tox-dev/py-filelock/blob/3.6.0/setup.cfg

Actions: 
1. Remove python from test/requires
2. Update home, dev, doc, doc_source urls