### PR TITLE
filelock 3.8.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "filelock" %}
-{% set version = "3.6.0" %}
+{% set version = "3.8.2" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85
+  sha256: 7565f628ea56bfcd8e54e42bdc55da899c85c1abfe1b5bcfd147e9188cebb3b2
 
 build:
   noarch: python


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 89713fb..193fc19 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "filelock" %}
-{% set version = "3.6.0" %}
+{% set version = "3.8.2" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85
+  sha256: 7565f628ea56bfcd8e54e42bdc55da899c85c1abfe1b5bcfd147e9188cebb3b2
 
 build:
   noarch: python

```

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/tox-dev/py-filelock/releases
[Diff between the latest and previous upstream releases](https://github.com/tox-dev/py-filelock/compare/3.6.0...3.8.2)
Requirements:
 * pyproject.toml:  https://github.com/tox-dev/py-filelock/blob/3.8.2/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: miniconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 3.8.2
 * Release on PyPi:
    * version: 3.9.0
    * date: 2022-12-28T16:32:56
* [PyPi history](https://pypi.org/project/filelock/#history)
 * Popularity: 
    * 3 months downloads: 1159594.0
    * All time:  9960436 downloads -  filelock  3.8.2  A platform independent file lock.  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/tox-dev/py-filelock/tree/3.8.2 exists
2. - [ ] The upstream url error:
    https://github.com/tox-dev/py-filelock
    
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/tox-dev/py-filelock/tree/3.8.2
    200
5. - [ ] Additional research
    https://github.com/tox-dev/py-filelock/issues
    
6. - [ ] `dev_url` error:
    https://github.com/tox-dev/py-filelock
    
7. - [ ] `doc_url` error:
    https://py-filelock.readthedocs.io/en/latest/
    
7. - [ ] `doc_source_url` error:
    https://github.com/tox-dev/py-filelock/tree/master/docs
    302
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE is present

16. - [x] license_family Public-Domain is present
17. - [x] License: Unlicense
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier   |
|:-------------|
| Unlicense    |
</details>

**Check dependency issues:**

<details>
../aggregate/filelock-feedstock/recipe/meta.yaml
Dependencies: ['wheel >=0.30.0', 'python >=3.7', 'setuptools >=41.0.0', 'setuptools_scm >=2', 'pip', 'python']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 17**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/filelock-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/filelock-feedstock/tree/3.8.2)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/filelock)
* [Diff between upstream and feature branch](https://github.com/conda-forge/filelock-feedstock/compare/main...AnacondaRecipes:3.8.2)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/filelock-feedstock/compare/master...AnacondaRecipes:3.8.2)
* [The last merged PRs](https://github.com/AnacondaRecipes/filelock-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 3.8.2 git@github.com:AnacondaRecipes/filelock-feedstock.git
```
